### PR TITLE
Allow downloading without subtitles, display default arg values in CLI

### DIFF
--- a/speechless/main.py
+++ b/speechless/main.py
@@ -10,7 +10,10 @@ def main():
   parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   subparsers = parser.add_subparsers(title='submodule')
   for submodule in SUBMODULES:
-    submodule.setup_arg_parser(subparsers.add_parser(submodule.NAME, help=submodule.DESCRIPTION))
+    submodule.setup_arg_parser(
+        subparsers.add_parser(submodule.NAME,
+                              help=submodule.DESCRIPTION,
+                              formatter_class=argparse.ArgumentDefaultsHelpFormatter))
   args = parser.parse_args()
 
   if len(args.__dict__) > 0 and hasattr(args, 'run'):


### PR DESCRIPTION
Now, when the `--with_audio` argument is used, audio and video are downloaded as a single file.