### PR TITLE
End encoding immediately when done, process only packets with pts > 0

### DIFF
--- a/speechless/edit_context/audio.py
+++ b/speechless/edit_context/audio.py
@@ -381,6 +381,8 @@ class AudioEditContext(EditCtx):
     assert src_packet.stream is self.src_stream
 
     for frame_idx, frame, frame_data in self._decode(src_packet):
+      if self.is_done:
+        break
       self.is_done = frame_idx + 1 >= self.dst_frames_no
       if len(self.workspaces) > 0 and self.workspaces[0].push_frame(frame_idx, frame, frame_data):
         while len(self.workspaces) > 0:

--- a/speechless/edit_context/common.py
+++ b/speechless/edit_context/common.py
@@ -102,7 +102,7 @@ class EditCtx:
     pts = []
     self.seek_beginning()
     for packet in self.src_stream.container.demux(self.src_stream):
-      if packet.pts is not None:
+      if packet.pts is not None and packet.pts >= 0:
         pts.append(packet.pts)
     if len(pts) < 2:  # there must be at least 2 frames
       return np.ndarray([]), False

--- a/speechless/edit_context/video.py
+++ b/speechless/edit_context/video.py
@@ -98,6 +98,8 @@ class VideoEditContext(EditCtx):
     assert src_packet.stream is self.src_stream
 
     for frame in src_packet.decode():
+      if self.is_done:
+        break
       frame_idx = self.frame_idx
       self.frame_idx += 1
       self.is_done = (self.frame_idx == len(self.dst_pts))


### PR DESCRIPTION
Decoded packed can produce more than one frame - end encoding immediately when done. Packets with pts < 0 are not frames.